### PR TITLE
fix: remove trailing space

### DIFF
--- a/src/pages/hostels.js
+++ b/src/pages/hostels.js
@@ -34,7 +34,7 @@ const DestinationsPage = ({ data }) => (
             fluid={hostel.featuredImage.fluid}
             key={hostel.id}
             alt={hostel.alt}
-            url={`hostels/${hostel.slug} `}
+            url={`hostels/${hostel.slug}`}
           />
         ))}
       </Container>


### PR DESCRIPTION
Fixes gatsbyjs/gatsby#9575

This (should!) fix the no-cache issue. You can see the error manifest itself by popping open the browser console and checking the logs, e.g.

```
console.js:35 A page wasn't found for "hostels/base-backpackers-sydney "
console.js:35 A page wasn't found for "hostels/base-backpackers-airlie-beach "
console.js:35 A page wasn't found for "hostels/base-backpackers-sydney "
2console.js:35 A page wasn't found for "hostels/base-backpackers-melbourne "
2console.js:35 A page wasn't found for "hostels/base-backpackers-sydney "
console.js:35 A page wasn't found for "hostels/base-backpackers-airlie-beach "
console.js:35 A page wasn't found for "hostels/base-backpackers-sydney "
console.js:35 A page wasn't found for "hostels/base-backpackers-melbourne "
console.js:35 A page wasn't found for "hostels/base-backpackers-sydney "
console.js:35 A page wasn't found for "hostels/base-backpackers-melbourne "
2console.js:35 A page wasn't found for "hostels/base-backpackers-sydney "
console.js:35 A page wasn't found for "hostels/base-backpackers-airlie-beach "
console.js:35 A page wasn't found for "hostels/base-backpackers-sydney "
```